### PR TITLE
Integrated SkySearch Simple & Minor Presentation Improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,9 +68,7 @@ We are in the process of preparing our research paper for submission to arXiv. O
 
 We created a detailed PowerPoint presentation to showcase the SkySearch project, including its objectives, methodology, and results. The presentation covers the technical aspects of integrating multimodal large language models with UAVs, as well as the challenges and solutions encountered during development.
 
-You can download the PowerPoint presentation [here](https://example.com/skysearch-presentation).
-
-You can read the UChicago Robotics Capstone report (PDF) [here](media/ADSP_34002_UChicago_Robotic_Capstone_SkySearch.pdf).
+You can download the PowerPoint presentation [here](media/ADSP_34002_UChicago_Robotic_Capstone_SkySearch.pdf).
 
 ## MS in Applied Data Science Conference Presentation
 

--- a/README.md
+++ b/README.md
@@ -7,11 +7,11 @@
 UChicago Robotics Capstone December 2024
 
 
-|||
+| Item | Details |
 | --- | --- |
-| Authors | Duncan Calvert, Joon Park, Zach Farahany, Mohammad Ayan Raheel|
-| Package | [![PyPI Latest Release](https://img.shields.io/pypi/v/pandas.svg)](https://pypi.org)|
-| Meta | [License - MIT](https://github.com/DonutsDuncan/SkySearch_UAV/blob/main/LICENSE)|
+| Authors | Duncan Calvert, Joon Park, Zach Farahany, Mohammad Ayan Raheel |
+| Package | [![PyPI Latest Release](https://img.shields.io/pypi/v/pandas.svg)](https://pypi.org) |
+| Meta | [License - MIT](https://github.com/DonutsDuncan/SkySearch_UAV/blob/main/LICENSE) |
 
 ## What is it?
 **SkySearch** is a groundbreaking research project that leverages multimodal large language models (MLLMs) to enable drones to autonomously perform open-vocabulary search tasks. Unlike traditional object detection systems constrained by fixed class labels and requiring retraining for new objects, SkySearch empowers drones to locate targets using natural language descriptions or reference images—without additional model fine-tuning.
@@ -41,6 +41,7 @@ For example, during a test flight, SkySearch successfully identified the book *C
 
 The SkySearch repository is organized for modular development, separating drone control logic, vision model utilities, and evaluation datasets. Below is a summary of the major folders and files:
 
+```text
 SkySearch/
 ├── media/images/                      # Project images, logos, and visual assets
 ├── parameters/                        # Prompt templates and model configuration files
@@ -57,6 +58,7 @@ SkySearch/
 ├── pyproject.toml / setup.cfg         # Packaging and installation metadata
 ├── README.md                          # Project overview and instructions
 └── .gitignore / .dockerignore         # Ignore rules for Git and Docker
+```
 
 ## ArXiv Paper Link
 

--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ We created a detailed PowerPoint presentation to showcase the SkySearch project,
 
 You can download the PowerPoint presentation [here](https://example.com/skysearch-presentation).
 
+You can read the UChicago Robotics Capstone report (PDF) [here](media/ADSP_34002_UChicago_Robotic_Capstone_SkySearch.pdf).
+
 ## MS in Applied Data Science Conference Presentation
 
 SkySearch was presented as part of the MS in Applied Data Science Conference, where it was awarded **1st place** in it's group for its innovative approach to autonomous UAV search and identification. The presentation highlighted the project's groundbreaking use of multimodal large language models and its potential real-world applications.


### PR DESCRIPTION
During the presentation of the capstone we got rid of some of the more advanced functionality that we were shooting for and decided to focus on deliverables we could complete on time. I just reduced the feature set to what we were doing in our slimmed down repo.

I also made some minor presentation based changes like a link to our presentation, and a link to the video of our presentation.

TLDR:
- Cleaned up & slimmed down the code to be SkySearch_Simple
- Added the presentation and a link to the video of our presentation (I don't have it but if anyone else does feel free to add it)